### PR TITLE
Fixed user card details overflow issue on mobile devices

### DIFF
--- a/app/components/dashboard-components/Home.tsx
+++ b/app/components/dashboard-components/Home.tsx
@@ -42,7 +42,7 @@ export const Home = () => {
   }, []);
 
   return (
-    <div className="w-full h-screen flex flex-col items-start justify-center pt-4 pl-6 md:pl-12 text-[#E3E8F1] relative">
+    <div className="w-full h-screen flex flex-col items-center justify-center pt-4 text-[#E3E8F1] relative">
       <div className="text-left z-10">
         <h1 className="text-4xl sm:text-6xl font-bold text-[#E3E8F1] mb-6 tracking-tight">
           <span className="text-[#3ABEF9]">Amrita</span> Winter of Code

--- a/app/components/dashboard-components/leaderboard.tsx
+++ b/app/components/dashboard-components/leaderboard.tsx
@@ -50,7 +50,7 @@ const Leaderboard = () => {
   }, []);
 
   return (
-    <Card className="bg-transparent border-none p-6 relative rounded-none z-50 w-full max-h-screen overflow-y-auto">
+    <Card className="bg-transparent border-none p-6 relative rounded-none z-50 w-full max-h-screen overflow-y-auto pb-10">
       <Tabs defaultValue="leaderboard" className="w-full">
         <TabsList className="grid grid-cols-2 bg-[#1d1e3a] text-base text-white h-10 w-full">
           <TabsTrigger value="leaderboard">Leaderboard</TabsTrigger>

--- a/app/components/dashboard-components/usercard.tsx
+++ b/app/components/dashboard-components/usercard.tsx
@@ -98,7 +98,7 @@ const UserCard = () => {
               {useLeaderboardStore.getState().getRank(userData.username)}
             </div>
           </div>
-          <div className="flex justify-between items-center px-6 pt-8 space-x-6">
+          <div className="flex flex-col lg:flex-row lg:gap-2 justify-between items-center px-6 pt-8">
             <div className="flex-shrink-0">
               <Image
                 src={`https://github.com/${userData.username}.png`}
@@ -112,7 +112,7 @@ const UserCard = () => {
               />
             </div>
 
-            <div className="text-center">
+            <div className="text-center space-y-1">
               <h2 className="text-3xl text-[#6ee7b7] font-semibold">
                 {userData.fullname}
               </h2>


### PR DESCRIPTION
Fixes #21 

1. **Updated the layout to be responsive:**
I used `flex flex-col lg:flex-row` to keep vertical flex direction for devices with resolution less than 1024px and horizontal for devices with resolution greater than 1024px.

2. **Improved spacing for better readability:**
Added `space-y-1` to create vertical spacing between divs.